### PR TITLE
Fix test.sh to accept both OAuth tokens and API keys

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,9 +19,9 @@ set -a
 source .env
 set +a
 
-# Check if tokens are set
-if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
-    echo "Error: CLAUDE_CODE_OAUTH_TOKEN not set in .env"
+# Check if tokens are set (either OAuth or API key)
+if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+    echo "Error: Either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY must be set in .env"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Fixed a bug in `test.sh` where it only accepted `CLAUDE_CODE_OAUTH_TOKEN` for authentication, even though the server supports both OAuth tokens and API keys.

## Problem
- `server.ts` accepts both `ANTHROPIC_API_KEY` **and** `CLAUDE_CODE_OAUTH_TOKEN` (see lines 134, 143, 185, 366)
- `test.sh` was only checking for `CLAUDE_CODE_OAUTH_TOKEN`
- Users running `setup-api-key.sh` (which sets `ANTHROPIC_API_KEY`) would get an error: "CLAUDE_CODE_OAUTH_TOKEN not set in .env"

## Solution
Updated the validation in `test.sh` to accept either authentication method, matching the server's behavior.

### Changes
```bash
# Before
if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
    echo "Error: CLAUDE_CODE_OAUTH_TOKEN not set in .env"
    exit 1
fi

# After
if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
    echo "Error: Either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY must be set in .env"
    exit 1
fi
```

## Test plan
- [x] Verified `./test.sh` works with `ANTHROPIC_API_KEY` set (no `CLAUDE_CODE_OAUTH_TOKEN`)
- [x] Verified container builds and starts successfully
- [x] Verified health check passes
- [x] Verified query endpoint works

## Impact
This aligns `test.sh` with the server's authentication logic and fixes the issue for users who run `setup-api-key.sh` instead of `setup-tokens.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)